### PR TITLE
feat: make inspection of the config possible

### DIFF
--- a/share/jupyter/voila/templates/gridstack/nbconvert_templates/grid.tpl
+++ b/share/jupyter/voila/templates/gridstack/nbconvert_templates/grid.tpl
@@ -87,7 +87,8 @@
         updateConfig();
         setCellNrs();
     });
-
+</script>
+<script type="text/javascript">
     function updateConfig() {
         const gsConfig = document.getElementById('gsConfig');
         const cells = []

--- a/share/jupyter/voila/templates/gridstack/nbconvert_templates/grid.tpl
+++ b/share/jupyter/voila/templates/gridstack/nbconvert_templates/grid.tpl
@@ -95,7 +95,6 @@
         const items = document.querySelectorAll('.grid-stack-item');
 
         items.forEach(item => {
-            console.log(item.dataset, item.dataset.cellNr);
             cells.push({
                 width: parseInt(item.dataset.gsWidth),
                 height: parseInt(item.dataset.gsHeight),

--- a/share/jupyter/voila/templates/gridstack/nbconvert_templates/grid.tpl
+++ b/share/jupyter/voila/templates/gridstack/nbconvert_templates/grid.tpl
@@ -1,5 +1,48 @@
 {%- extends 'gridstack_base.tpl' -%}
 
+{% block html_head_css %}
+{{ super() }}
+
+<style>
+.config {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1000;
+}
+
+.config .openConfig {
+    text-align: right;
+}
+
+.config .openConfig i {
+    margin: 4px;
+    cursor: pointer;
+}
+
+#gsConfig {
+    background-color: white;
+    font-size: 11px;
+    border: 1px solid black;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+#gsConfig .output {
+    background-color: #EDEDED;
+    margin-top: 4px;
+    margin-bottom: 4px;
+    padding: 8px;
+}
+
+.config pre {
+    font-size: 11px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+</style>
+{% endblock html_head_css %}
+
 {% block html_head_js scoped %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
@@ -39,8 +82,52 @@
             }
         }).on('resizestop', function(event, elem) {
             resize_workaround()
-        });
+        }).on('change', updateConfig);
+
+        updateConfig();
+        setCellNrs();
     });
+
+    function updateConfig() {
+        const gsConfig = document.getElementById('gsConfig');
+        const cells = []
+        const items = document.querySelectorAll('.grid-stack-item');
+
+        items.forEach(item => {
+            console.log(item.dataset, item.dataset.cellNr);
+            cells.push({
+                width: parseInt(item.dataset.gsWidth),
+                height: parseInt(item.dataset.gsHeight),
+                col: parseInt(item.dataset.gsX),
+                row: parseInt(item.dataset.gsY),
+            });
+        });
+
+        gsConfig.innerHTML = cells.map((cell, index) =>
+            `<div class="output">
+                Output ${index + 1}
+                <pre>${JSON.stringify(cell, null, 2)}</pre>
+            </div>`
+        ).join('');
+    }
+
+    let open = false;
+
+    function showConfig() {
+        open = !open
+
+        const gsConfig = document.getElementById('gsConfig');
+        gsConfig.style.visibility = open ? 'visible' : 'hidden';
+    }
+
+    function setCellNrs() {
+        let count = 1;
+        const items = document.querySelectorAll('.cell_output');
+        items.forEach(item => {
+            item.innerHTML = 'Output ' + count;
+            count++;
+        });
+    }
 </script>
 {{ super() }}
 {% endblock html_head_js %}
@@ -51,9 +138,9 @@
     {% set view_data = cell_jupyter_dashboards.get('views', {}).get(active_view, {}) %}
     {% set hidden = view_data.get('hidden') %}
     {% set auto_position = ('row' not in view_data or 'col' not in view_data) %}
-    {%- if not hidden and cell.cell_type in ['markdown', 'code'] %} 
+    {%- if not hidden and cell.cell_type in ['markdown', 'code'] %}
     <div class="grid-stack-item"
-         data-gs-width="{{ view_data.width | default(12) }}" 
+         data-gs-width="{{ view_data.width | default(12) }}"
          data-gs-height="{{ view_data.height | default(2) }}"
          {% if auto_position %}
          data-gs-auto-position=true
@@ -66,6 +153,7 @@
             {% if resources.gridstack.show_handles %}
             <div class="gridhandle">
                 <i class=" fa fa-arrows"></i>
+                <span class="cell_output"></span>
             </div>
             {% endif %}
             {{ super() }}
@@ -82,4 +170,14 @@
         </div>
     </div>
 </section>
+
+{% if resources.gridstack.show_handles %}
+<div class="config">
+    <div class="openConfig">
+        <i class="fa fa-cog"  onclick="showConfig()"></i>
+    </div>
+    <div id="gsConfig" style="visibility: hidden">
+    </div>
+</div>
+{% endif %}
 {% endblock body %}


### PR DESCRIPTION
After setting up the layout, the config can be inspected and copy
pasted to the notebook cells metadata. Until there is a way to
directly persist to a notebook, this makes the manual configuration
a bit easier.

Related issue: #34

![gridstack](https://user-images.githubusercontent.com/46192475/79780696-93d97580-833c-11ea-8b05-05c7a14ad12a.gif)