### PR TITLE
fix: visibility hidden blocked mouse, causing some handles not to work

### DIFF
--- a/share/jupyter/nbconvert/templates/gridstack/grid_type.html.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/grid_type.html.j2
@@ -117,7 +117,7 @@
         open = !open
 
         const gsConfig = document.getElementById('gsConfig');
-        gsConfig.style.visibility = open ? 'visible' : 'hidden';
+        gsConfig.style.display = open ? '' : 'none';
     }
 
     function setCellNrs() {
@@ -178,7 +178,7 @@
     <div class="openConfig">
         <i class="fa fa-cog"  onclick="showConfig()"></i>
     </div>
-    <div id="gsConfig" style="visibility: hidden">
+    <div id="gsConfig" style="display: none">
     </div>
 </div>
 {% endif %}


### PR DESCRIPTION
The handles on the right of the screen basically did not work because the config screen blocked it (even when not visible)
cc @SylvainCorlay 