### PR TITLE
Update the server extension to the refactored template system

### DIFF
--- a/voila-gridstack/server_extension.py
+++ b/voila-gridstack/server_extension.py
@@ -21,18 +21,12 @@ def load_jupyter_server_extension(server_app):
 
     web_app = server_app.web_app
 
-    nbconvert_template_paths = []
-    static_paths = [STATIC_ROOT]
-    template_paths = []
-
     voila_configuration = VoilaConfiguration(parent=server_app)
     voila_configuration.template = "gridstack"
     voila_configuration.config.VoilaConfiguration.resources = {"gridstack": {"show_handles": False, "extension": True}}
 
-    collect_template_paths(
-        nbconvert_template_paths,
-        static_paths,
-        template_paths,
+    template_paths = collect_template_paths(
+        ['voila', 'nbconvert'],
         voila_configuration.template
     )
 
@@ -42,7 +36,7 @@ def load_jupyter_server_extension(server_app):
     web_app.add_handlers(host_pattern, [
         (url_path_join(base_url, '/voila/dashboard/(.*)'), VoilaHandler, {
             'config': server_app.config,
-            'nbconvert_template_paths': nbconvert_template_paths,
+            'template_paths': template_paths,
             'voila_configuration': voila_configuration
         }),
     ])

--- a/voila-gridstack/server_extension.py
+++ b/voila-gridstack/server_extension.py
@@ -9,7 +9,7 @@
 
 from jupyter_server.utils import url_path_join
 
-from voila.paths import STATIC_ROOT, collect_template_paths
+from voila.paths import collect_template_paths
 from voila.handler import VoilaHandler
 from voila.configuration import VoilaConfiguration
 


### PR DESCRIPTION
Installing `voila-gridstack` from source on the latest master would show the following error:

```
    ValueError: No template sub-directory with name 'base' found in the following paths:
```

This change updates the `voila-gridstack` server extension to use the refactored template system.

This might also fix #47.