### PR TITLE
Fixes for the classic notebook editor

### DIFF
--- a/examples/scotch_dashboard.ipynb
+++ b/examples/scotch_dashboard.ipynb
@@ -9,7 +9,7 @@
       "views": {
        "grid_default": {
         "col": 0,
-        "height": 2,
+        "height": 3,
         "hidden": false,
         "row": 0,
         "width": 12
@@ -437,7 +437,7 @@
         "col": 0,
         "height": 2,
         "hidden": false,
-        "row": 2,
+        "row": 3,
         "width": 12
        },
        "report_default": {
@@ -480,7 +480,7 @@
         "col": 0,
         "height": 7,
         "hidden": false,
-        "row": 18,
+        "row": 19,
         "width": 4
        },
        "report_default": {}
@@ -523,7 +523,7 @@
         "col": 4,
         "height": 11,
         "hidden": false,
-        "row": 4,
+        "row": 5,
         "width": 8
        },
        "report_default": {
@@ -577,7 +577,7 @@
         "col": 0,
         "height": 2,
         "hidden": false,
-        "row": 4,
+        "row": 5,
         "width": 4
        },
        "report_default": {
@@ -618,7 +618,7 @@
         "col": 0,
         "height": 3,
         "hidden": false,
-        "row": 15,
+        "row": 16,
         "width": 12
        },
        "report_default": {

--- a/voila-gridstack/static/extension.js
+++ b/voila-gridstack/static/extension.js
@@ -104,6 +104,7 @@ define(['jquery',
                     }
 
                     // hide inputs and prompts
+                    $('#notebook-container').css('width', '100%');
                     $('.code_cell > .input').hide();
                     $('.prompt').hide();
 
@@ -151,7 +152,8 @@ define(['jquery',
                     grid = gridstack.init({
                         alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
                         resizable: {
-                            handles: 'e, se, s, sw, w'
+                            handles: 'e, se, s, sw, w',
+                            autoHide: true
                         },
                         cellHeight: active_view.defaultCellHeight,
                         margin: active_view.cellMargin,

--- a/voila-gridstack/static/extension.js
+++ b/voila-gridstack/static/extension.js
@@ -168,9 +168,6 @@ define(['jquery',
                         window.dispatchEvent(new Event('resize'));
                     });
 
-                    // hides code cells with empty output, and raw text cells
-                    voila_gridstack.hide_elements(grid);
-
                     // adds 'on change' listener on grid to save position and size in metadata
                     voila_gridstack.init_on_change(grid);
 

--- a/voila-gridstack/static/voila-gridstack.css
+++ b/voila-gridstack/static/voila-gridstack.css
@@ -31,6 +31,7 @@
 
 #notebook-container {
     background-color: var(--jp-layout-color2);
+    padding: 0;
 }
 
 .ui-resizable-se {

--- a/voila-gridstack/static/voila-gridstack.js
+++ b/voila-gridstack/static/voila-gridstack.js
@@ -63,6 +63,9 @@ define(['jquery',
     function hide_elements(grid) {
         grid.engine.nodes.forEach( function (item) {
             cell = $(item.el).find(".cell").first().data('cell');
+            if (!cell) {
+                return;
+            }
             if ((cell.cell_type == "code" && !cell.output_area.outputs.length) || cell.cell_type == "raw") {
                 $(item.el).addClass('grid-stack-item-hidden');
                 grid.removeWidget(item.el, false);
@@ -97,6 +100,7 @@ define(['jquery',
                 gridstack_meta.height = item.height;
             });
 
+            hide_elements(grid);
             Jupyter.notebook.save_notebook();
         });
 


### PR DESCRIPTION
Follow-up to #56. 

Fixes #63 

### Changes

- Add back autoHide and notebook container full width
- Fix hidden cells

![hidden-cells](https://user-images.githubusercontent.com/591645/93894272-d7228080-fcee-11ea-863b-b3c46c5622ec.gif)
