### PR TITLE
Handle gridstack events

### DIFF
--- a/examples/scotch_dashboard.ipynb
+++ b/examples/scotch_dashboard.ipynb
@@ -27,14 +27,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 181,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 29,
+        "width": 12
        },
        "report_default": {
         "hidden": true
@@ -52,14 +56,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 182,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 20,
+        "width": 12
        },
        "report_default": {
         "hidden": true
@@ -77,14 +85,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 183,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 37,
+        "width": 12
        },
        "report_default": {}
       }
@@ -277,14 +289,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 184,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 27,
+        "width": 12
        },
        "report_default": {}
       }
@@ -299,14 +315,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 185,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 35,
+        "width": 12
        },
        "report_default": {}
       }
@@ -322,14 +342,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 186,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 22,
+        "width": 12
        },
        "report_default": {
         "hidden": false
@@ -363,14 +387,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 187,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 31,
+        "width": 12
        },
        "report_default": {
         "hidden": false
@@ -390,14 +418,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 188,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
       "views": {
        "grid_default": {
-        "hidden": true
+        "col": 0,
+        "height": 2,
+        "hidden": true,
+        "row": 33,
+        "width": 12
        },
        "report_default": {
         "hidden": false
@@ -427,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 189,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -451,7 +483,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "818877519fd14945aefe3be41f893dfb",
+       "model_id": "c4b04942ec244f5d90a15ad1c9fda91d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -470,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 190,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -492,7 +524,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe86ed9f5ccb49fc98e059974e6f7270",
+       "model_id": "3952fa3568d146bcb0981c6ca1b94d6f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -513,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 191,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -537,7 +569,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6ae7e91b5bc141eda50f69a740a71eb3",
+       "model_id": "95fbf8811b644431839393182b7626d1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -567,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 192,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -591,7 +623,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "396a83be05cc4eda99958e2512670944",
+       "model_id": "503e009711db4d6cb2dc7060ba89fe94",
        "version_major": 2,
        "version_minor": 0
       },
@@ -670,7 +702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   },
   "voila": {
    "template": "gridstack"

--- a/examples/scotch_dashboard.ipynb
+++ b/examples/scotch_dashboard.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 1,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 2,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 3,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 4,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 5,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 6,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 7,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 8,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -459,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 9,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -483,7 +483,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c4b04942ec244f5d90a15ad1c9fda91d",
+       "model_id": "67c1f2c6f9d8454ab4b6d84bc0b947ac",
        "version_major": 2,
        "version_minor": 0
       },
@@ -502,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 10,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -524,7 +524,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3952fa3568d146bcb0981c6ca1b94d6f",
+       "model_id": "889da699826d4419aad4bc268a9e6932",
        "version_major": 2,
        "version_minor": 0
       },
@@ -545,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": 11,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -569,7 +569,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "95fbf8811b644431839393182b7626d1",
+       "model_id": "e9d1411b04d348f2ae2080571f992f3f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -599,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 12,
    "metadata": {
     "extensions": {
      "jupyter_dashboards": {
@@ -623,7 +623,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "503e009711db4d6cb2dc7060ba89fe94",
+       "model_id": "24efbfeb25c04a71912eb6c1acebcc18",
        "version_major": 2,
        "version_minor": 0
       },
@@ -702,7 +702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.5"
   },
   "voila": {
    "template": "gridstack"

--- a/examples/scotch_dashboard.ipynb
+++ b/examples/scotch_dashboard.ipynb
@@ -34,11 +34,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 29,
-        "width": 12
+        "hidden": true
        },
        "report_default": {
         "hidden": true
@@ -63,11 +59,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 20,
-        "width": 12
+        "hidden": true
        },
        "report_default": {
         "hidden": true
@@ -92,11 +84,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 37,
-        "width": 12
+        "hidden": true
        },
        "report_default": {}
       }
@@ -296,11 +284,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 27,
-        "width": 12
+        "hidden": true
        },
        "report_default": {}
       }
@@ -322,11 +306,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 35,
-        "width": 12
+        "hidden": true
        },
        "report_default": {}
       }
@@ -349,11 +329,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 22,
-        "width": 12
+        "hidden": true
        },
        "report_default": {
         "hidden": false
@@ -394,11 +370,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 31,
-        "width": 12
+        "hidden": true
        },
        "report_default": {
         "hidden": false
@@ -425,11 +397,7 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 2,
-        "hidden": true,
-        "row": 33,
-        "width": 12
+        "hidden": true
        },
        "report_default": {
         "hidden": false
@@ -483,7 +451,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "67c1f2c6f9d8454ab4b6d84bc0b947ac",
+       "model_id": "c91fbed0de4d432a92544374cf112414",
        "version_major": 2,
        "version_minor": 0
       },
@@ -524,7 +492,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "889da699826d4419aad4bc268a9e6932",
+       "model_id": "578366904ef74eac837fa42027df5ff5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -569,7 +537,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9d1411b04d348f2ae2080571f992f3f",
+       "model_id": "3da6b641bd394713810ddade94eebb80",
        "version_major": 2,
        "version_minor": 0
       },
@@ -623,7 +591,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "24efbfeb25c04a71912eb6c1acebcc18",
+       "model_id": "7b94076c4ea243d48a028ad2ac6b1549",
        "version_major": 2,
        "version_minor": 0
       },
@@ -702,7 +670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.0"
   },
   "voila": {
    "template": "gridstack"

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup_args = {
     ],
     'extras_require': {
         'test': [
+            'ipykernel',
             'pytest',
             'pytest-tornasync',
             'lxml'

--- a/share/jupyter/nbconvert/templates/gridstack/grid_type.html.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/grid_type.html.j2
@@ -145,6 +145,7 @@
          data-gs-width="{{ view_data.width | default(12) }}"
          data-gs-height="{{ view_data.height | default(2) }}"
          {% if auto_position %}
+         data-gs-auto-position=true
          {% else %}
          data-gs-y="{{ view_data.row }}"
          data-gs-x="{{ view_data.col }}"

--- a/share/jupyter/nbconvert/templates/gridstack/grid_type.html.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/grid_type.html.j2
@@ -145,7 +145,6 @@
          data-gs-width="{{ view_data.width | default(12) }}"
          data-gs-height="{{ view_data.height | default(2) }}"
          {% if auto_position %}
-         data-gs-auto-position=true
          {% else %}
          data-gs-y="{{ view_data.row }}"
          data-gs-x="{{ view_data.col }}"

--- a/voila-gridstack/static/extension.js
+++ b/voila-gridstack/static/extension.js
@@ -131,7 +131,7 @@ define(['jquery',
                             console.error('Error during gridstack initialization\n', err);
                         }
 
-                        position = (!gridstack_meta.hasOwnProperty('col')) ?
+                        position = (!gridstack_meta.hasOwnProperty('col')) ? 
                                         "data-gs-auto-position='true'" :
                                         "data-gs-x='" + gridstack_meta.col + "' data-gs-y='" + gridstack_meta.row + "'";
 
@@ -150,6 +150,7 @@ define(['jquery',
 
                     // init GridStack
                     grid = gridstack.init({
+                        float: true,
                         alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
                         resizable: {
                             handles: 'e, se, s, sw, w',
@@ -175,7 +176,7 @@ define(['jquery',
                     window.dispatchEvent(new Event('resize'));
 
                     // saves initial positions and sizes in metadata
-                    $('.grid-stack').trigger("change", grid.engine.nodes[0]);
+                    $('.grid-stack').trigger("change", grid.engine.nodes);
                 });
 
                 // removes spinner and show notebook as gridstack

--- a/voila-gridstack/static/extension.js
+++ b/voila-gridstack/static/extension.js
@@ -31,6 +31,12 @@ define(['jquery',
             // disables button
             $('#btn-voila-gridstack_notebook').prop( "disabled", true );
 
+            // unsubsribe from events
+            grid.off('added');
+            grid.off('change');
+            grid.off('removed');
+            grid.off('resizestop');
+
             // saves notebook then formats HTML
             Jupyter.notebook.save_notebook().then(function () {
 
@@ -131,7 +137,7 @@ define(['jquery',
                             console.error('Error during gridstack initialization\n', err);
                         }
 
-                        position = (!gridstack_meta.hasOwnProperty('col')) ? 
+                        position = (!gridstack_meta.hasOwnProperty('col')) ?
                                         "data-gs-auto-position='true'" :
                                         "data-gs-x='" + gridstack_meta.col + "' data-gs-y='" + gridstack_meta.row + "'";
 
@@ -174,6 +180,7 @@ define(['jquery',
 
                     // fake window resize event at init to display bqplot without resizing tile
                     window.dispatchEvent(new Event('resize'));
+
 
                     // saves initial positions and sizes in metadata
                     $('.grid-stack').trigger("change", grid.engine.nodes);

--- a/voila-gridstack/static/voila-gridstack.js
+++ b/voila-gridstack/static/voila-gridstack.js
@@ -79,7 +79,7 @@ define(['jquery',
                 cell.output_area.outputs.length === 0) ||
                 cell.cell_type === "raw" ) {
 
-                cell.metadata.extensions.jupyter_dashboards.views[active_view_name].hidden = true;
+                cell.metadata.extensions.jupyter_dashboards.views[active_view_name] = { hidden: true };
                 $(item.el).addClass('grid-stack-item-hidden');
                 grid.removeWidget(item.el, false);
             }
@@ -102,8 +102,16 @@ define(['jquery',
                     return;
                 }
 
+                var views = cell.metadata.extensions.jupyter_dashboards.views;
                 active_view_name = Jupyter.notebook.metadata.extensions.jupyter_dashboards.activeView;
-                gridstack_meta = cell.metadata.extensions.jupyter_dashboards.views[active_view_name];
+
+                // keep only the "hidden" field if hidden
+                if (views[active_view_name].hidden) {
+                    views[active_view_name] = { hidden: true };
+                    return;
+                }
+
+                gridstack_meta = views[active_view_name];
 
                 // modify cell's gridstack metadata
                 gridstack_meta.col = item.x;

--- a/voila-gridstack/static/voila-gridstack.js
+++ b/voila-gridstack/static/voila-gridstack.js
@@ -63,16 +63,26 @@ define(['jquery',
     function hide_elements(grid) {
         grid.engine.nodes.forEach( function (item) {
             cell = $(item.el).find(".cell").first().data('cell');
+            active_view_name = Jupyter.notebook.metadata.extensions.jupyter_dashboards.activeView;
+
             if (!cell) {
+                console.info("None: ", cell);
                 return;
-            }
-            if ((cell.cell_type == "code" && !cell.output_area.outputs.length) || cell.cell_type == "raw") {
+            } else if (cell.metadata.extensions.jupyter_dashboards.views[active_view_name].hidden) {
+                console.info("Hidden: ");
                 $(item.el).addClass('grid-stack-item-hidden');
                 grid.removeWidget(item.el, false);
-
-                active_view_name = Jupyter.notebook.metadata.extensions.jupyter_dashboards.activeView;
+            } else if ((cell.cell_type === "code" &&
+                cell.input_prompt_number !== undefined &&
+                cell.output_area.outputs.length === 0) || 
+                cell.cell_type === "raw" ) {
+                
+                console.info("Other: ");
                 cell.metadata.extensions.jupyter_dashboards.views[active_view_name].hidden = true;
+                $(item.el).addClass('grid-stack-item-hidden');
+                grid.removeWidget(item.el, false);
             }
+            console.info(cell);
         });
     }
 
@@ -93,7 +103,7 @@ define(['jquery',
                 gridstack_meta = cell.metadata.extensions.jupyter_dashboards.views[active_view_name];
 
                 // modify cell's gridstack metadata
-                gridstack_meta.hidden = false;
+                // gridstack_meta.hidden = false;
                 gridstack_meta.col = item.x;
                 gridstack_meta.row = item.y;
                 gridstack_meta.width = item.width;


### PR DESCRIPTION
Follow-up to #66.

cc @hbcarlos this PR continues from this commit: 6f25a82f71eb577a6f93b7c6e62c0aef761e72f6

And handles the `added` and `removed` gridstack events to trigger `hide_elements`

![hidden-cells-2](https://user-images.githubusercontent.com/591645/96690362-dfb8b600-1383-11eb-9cbb-334302ba4ec5.gif)
