### PR TITLE
Update gridstack 3.1

### DIFF
--- a/packages/jupyterlab-gridstack/package.json
+++ b/packages/jupyterlab-gridstack/package.json
@@ -55,7 +55,7 @@
     "@jupyterlab/ui-components": "^3.0.0",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/widgets": "^1.17.0",
-    "gridstack": "^2.1.0",
+    "gridstack": "^3.1.3",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -15,6 +15,8 @@ import {
 
 import 'gridstack/dist/gridstack.css';
 
+import 'gridstack/dist/h5/gridstack-dd-native';
+
 import { GridStackItem } from './item';
 
 import { DashboardView, DashboardCellView } from '../format';
@@ -255,7 +257,12 @@ export class GridStackLayout extends Layout {
   updateGridItem(id: string, info: DashboardCellView): void {
     const items = this._grid.getGridItems();
     const item = items?.find(value => value.gridstackNode?.id === id);
-    this._grid.update(item!, info.col, info.row, info.width, info.height);
+    this._grid.update(item!, {
+      x: info.col,
+      y: info.row,
+      w: info.width,
+      h: info.height
+    });
   }
 
   /**

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/widget.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/widget.ts
@@ -262,8 +262,8 @@ export class GridStackWidget extends Widget {
         hidden: false,
         col: el.x ?? 0,
         row: el.y ?? 0,
-        width: el.width ?? 2,
-        height: el.height ?? 2
+        width: el.w ?? 2,
+        height: el.h ?? 2
       });
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6036,10 +6036,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-gridstack@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-2.2.0.tgz#56e14dedc838d9aa87289e801bec7603b552ba1c"
-  integrity sha512-qJezPsH445ct+yNjBSVTvMP/SpC/Pa8V2H1b8SPuB0uVOKV+QFOFOThMRToSGbPwH7NCc3A7WOjTzRx+jnUFaA==
+gridstack@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-3.1.3.tgz#982572b5d7b3608ab0463821a9798cab3766acaf"
+  integrity sha512-FNmuz5d1qRFXxK/tWj8PsAECyiFOX6Pnj4aaW+zd9BcTI9yY1hT7gq8y5CTBZ3vIy7VE+99jDwvb9WWchs0xlw==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Updated gridstack 3.1 for jupyterlab-gridstack

![Grabación de pantalla 2021-01-03 a las 17 01 55](https://user-images.githubusercontent.com/26092748/103483283-707d2a80-4de6-11eb-9f29-a2b81cdcaade.gif)

Still a small issue on gridtack for OSX and Chrome, there is a small delay on dropping grid item.