### PR TITLE
Add base_url fixture for the tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from jupyter_packaging import (
     combine_commands, skip_if_exists
 )
 import setuptools
-from setuptools.command.develop import develop
 
 try:
     import jupyter_core.paths as jupyter_core_paths
@@ -112,13 +111,12 @@ setup_args = dict(
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyterlab_widgets>=1.0.0rc1",
+        "jupyterlab_widgets~=1.0",
         "voila>=0.2.0,<0.3.0"
     ],
     extras_require={
         "test": [
             'ipykernel',
-            'jupyter_server~=1.0.1',
             'pytest',
             'pytest-tornasync',
             'lxml'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ def voila_app(voila_args, voila_config):
 
 
 @pytest.fixture
+def base_url():
+    return "/"
+
+
+@pytest.fixture
 def app(voila_app):
     return voila_app.app
 


### PR DESCRIPTION
Fixes #70 

We probably want to wait for voila to switch to the Jupyter Server `ExtensionApp` before starting using the Jupyter Server pytest fixtures like `jp_base_url` and `jp_fetch`.

Also updates the `jupyterlab_widgets` dependency to the final version.