### PR TITLE
Add extra dependencies to the release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@
 Creating a new environment can help avoid pushing local changes and any extra tag.
 
 ```bash
-mamba create -q -y -n voila-gridstack-release -c conda-forge twine nodejs keyring pip matplotlib
+mamba create -q -y -n voila-gridstack-release -c conda-forge twine nodejs keyring pip matplotlib jupyter-packaging jupyterlab
 conda activate voila-gridstack-release
 ```
 


### PR DESCRIPTION
Add `jupyter-packaging` and `jupyterlab` to the dependency for the release environment.

`jupyterlab` is needed to build the prebuilt assets for the lab extension. 