### PR TITLE
Improve drag & drop from notebook

### DIFF
--- a/packages/jupyterlab-gridstack/package.json
+++ b/packages/jupyterlab-gridstack/package.json
@@ -43,8 +43,8 @@
     "watch:src": "tsc -w"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^4.0.0-alpha.2",
-    "@jupyter-widgets/jupyterlab-manager": "^3.0.0-alpha.2",
+    "@jupyter-widgets/base": "^4.0.0",
+    "@jupyter-widgets/jupyterlab-manager": "^3.0.0",
     "@jupyterlab/application": "^3.0.0",
     "@jupyterlab/apputils": "^3.0.0",
     "@jupyterlab/cells": "^3.0.0",
@@ -55,7 +55,7 @@
     "@jupyterlab/ui-components": "^3.0.0",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/widgets": "^1.17.0",
-    "gridstack": "^4.0.0",
+    "gridstack": "^3.1.3",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/jupyterlab-gridstack/package.json
+++ b/packages/jupyterlab-gridstack/package.json
@@ -55,7 +55,7 @@
     "@jupyterlab/ui-components": "^3.0.0",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/widgets": "^1.17.0",
-    "gridstack": "^3.1.3",
+    "gridstack": "^4.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -6,12 +6,7 @@ import { Signal, ISignal } from '@lumino/signaling';
 
 import { Message, MessageLoop } from '@lumino/messaging';
 
-import {
-  GridStack,
-  GridHTMLElement,
-  GridStackNode,
-  GridItemHTMLElement
-} from 'gridstack';
+import { GridStack, GridStackNode, GridItemHTMLElement } from 'gridstack';
 
 import 'gridstack/dist/gridstack.css';
 
@@ -41,6 +36,8 @@ export class GridStackLayout extends Layout {
 
     this._grid = GridStack.init(
       {
+        // acceptWidgets: true,
+        dragIn: '#tab-key-0',
         float: true,
         column: this._columns,
         margin: this._margin,
@@ -60,14 +57,20 @@ export class GridStackLayout extends Layout {
 
     this._grid.on(
       'change',
-      (event: Event, items: GridHTMLElement | GridStackNode[] | undefined) => {
+      (
+        event: Event,
+        items?: GridItemHTMLElement | GridStackNode | GridStackNode[]
+      ) => {
         this._onChange(event, items as GridStackNode[]);
       }
     );
 
     this._grid.on(
       'removed',
-      (event: Event, items: GridHTMLElement | GridStackNode[] | undefined) => {
+      (
+        event: Event,
+        items?: GridItemHTMLElement | GridStackNode | GridStackNode[]
+      ) => {
         if ((items as GridStackNode[]).length <= 1) {
           this._onRemoved(event, items as GridStackNode[]);
         }
@@ -204,6 +207,10 @@ export class GridStackLayout extends Layout {
       this._updateBackgroundSize();
       this.parent!.update();
     }
+  }
+
+  get grid(): GridStack {
+    return this._grid;
   }
 
   /**

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -265,6 +265,7 @@ export class GridStackLayout extends Layout {
     MessageLoop.sendMessage(item, Widget.Msg.BeforeAttach);
     this._grid.addWidget(item.node, options);
     MessageLoop.sendMessage(item, Widget.Msg.AfterAttach);
+    this.updateGridItem(id, info);
   }
 
   /**

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -41,8 +41,6 @@ export class GridStackLayout extends Layout {
 
     this._grid = GridStack.init(
       {
-        // acceptWidgets: true,
-        dragIn: '#tab-key-0',
         float: true,
         column: this._columns,
         margin: this._margin,
@@ -217,6 +215,9 @@ export class GridStackLayout extends Layout {
     }
   }
 
+  /**
+   * Helper to get access to underlying GridStack object
+   */
   get grid(): GridStack {
     return this._grid;
   }

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -31,6 +31,11 @@ export class GridStackLayout extends Layout {
     this._cellHeight = info.defaultCellHeight;
     this._columns = info.maxColumns;
 
+    this._helperMessage = document.createElement('div');
+    this._helperMessage.appendChild(document.createElement('p')).textContent =
+      'Drag and drop cells here to start building the dashboard.';
+    this._helperMessage.className = 'jp-grid-helper';
+
     this._gridHost = document.createElement('div');
     this._gridHost.className = 'grid-stack';
 
@@ -100,6 +105,9 @@ export class GridStackLayout extends Layout {
   init(): void {
     super.init();
     this.parent!.node.appendChild(this._gridHost);
+    if (this._gridItems.length === 0) {
+      this._gridHost.insertAdjacentElement('beforebegin', this._helperMessage);
+    }
     // fake window resize event to resize bqplot
     window.dispatchEvent(new Event('resize'));
   }
@@ -250,6 +258,10 @@ export class GridStackLayout extends Layout {
 
     this._gridItems.push(item);
 
+    if (this._gridItems.length === 1) {
+      this.parent!.node.removeChild(this._helperMessage);
+    }
+
     MessageLoop.sendMessage(item, Widget.Msg.BeforeAttach);
     this._grid.addWidget(item.node, options);
     MessageLoop.sendMessage(item, Widget.Msg.AfterAttach);
@@ -285,6 +297,10 @@ export class GridStackLayout extends Layout {
       this._gridItems = this._gridItems.filter(obj => obj.cellId !== id);
       this._grid.removeWidget(item, true, false);
     }
+
+    if (this._gridItems.length === 0) {
+      this._gridHost.insertAdjacentElement('beforebegin', this._helperMessage);
+    }
   }
 
   /**
@@ -317,4 +333,5 @@ export class GridStackLayout extends Layout {
   private _grid: GridStack;
   private _gridItems: GridStackItem[] = [];
   private _gridItemChanged = new Signal<this, GridStackNode[]>(this);
+  private _helperMessage: HTMLElement;
 }

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/widget.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/widget.ts
@@ -36,6 +36,7 @@ export class GridStackWidget extends Widget {
     this.addClass('grid-editor');
     this._model = model;
     this._shadowWidget = document.createElement('div');
+    this._shadowWidget.className = 'jp-grid-placeholder';
     this._shadowWidget.style.display = 'none';
 
     this.layout = new GridStackLayout(this._model.info);
@@ -46,6 +47,13 @@ export class GridStackWidget extends Widget {
       this._model.cellRemoved.connect(this._removeCell, this);
       this._model.contentChanged.connect(this._updateGridItems, this);
     });
+  }
+
+  /**
+   * Update the layout to reclaim any empty space
+   */
+  compact(): void {
+    this.layout.grid.compact();
   }
 
   /**
@@ -324,8 +332,7 @@ export class GridStackWidget extends Widget {
     // if (!widget) {
     //   return;
     // }
-    // widget.removeClass('jp-gridstack-cell-in-motion');v
-    this.layout.grid.compact();
+    // widget.removeClass('jp-gridstack-cell-in-motion');
     event.preventDefault();
     event.stopPropagation();
   }
@@ -434,7 +441,6 @@ export class GridStackWidget extends Widget {
       }
     }
 
-    this.layout.grid.compact();
     this.removeClass('pr-DropTarget');
   }
 

--- a/packages/jupyterlab-gridstack/src/editor/toolbar/compact.tsx
+++ b/packages/jupyterlab-gridstack/src/editor/toolbar/compact.tsx
@@ -1,0 +1,35 @@
+import { ReactWidget, ToolbarButtonComponent } from '@jupyterlab/apputils';
+
+import * as React from 'react';
+
+import { compactIcon } from '../../icons';
+
+import { GridStackWidget } from '../gridstack/widget';
+
+import { VoilaGridStackPanel } from '../panel';
+
+/**
+ * A toolbar widget to open the dashboard metadata editor dialog.
+ */
+export default class Compact extends ReactWidget {
+  constructor(panel: VoilaGridStackPanel) {
+    super();
+    this._panel = panel;
+  }
+
+  render(): JSX.Element {
+    const onClick = (): void => {
+      (this._panel?.widgets[0] as GridStackWidget)?.compact();
+    };
+
+    return (
+      <ToolbarButtonComponent
+        icon={compactIcon}
+        onClick={onClick}
+        tooltip={'Compact the grid towards the top left corner'}
+      />
+    );
+  }
+
+  private _panel: VoilaGridStackPanel;
+}

--- a/packages/jupyterlab-gridstack/src/editor/toolbar/compact.tsx
+++ b/packages/jupyterlab-gridstack/src/editor/toolbar/compact.tsx
@@ -9,7 +9,7 @@ import { GridStackWidget } from '../gridstack/widget';
 import { VoilaGridStackPanel } from '../panel';
 
 /**
- * A toolbar widget to open the dashboard metadata editor dialog.
+ * A toolbar widget to compact the dashboard on the top left corner.
  */
 export default class Compact extends ReactWidget {
   constructor(panel: VoilaGridStackPanel) {

--- a/packages/jupyterlab-gridstack/src/editor/widget.ts
+++ b/packages/jupyterlab-gridstack/src/editor/widget.ts
@@ -8,12 +8,13 @@ import { Token } from '@lumino/coreutils';
 
 import { VoilaGridStackPanel } from './panel';
 
+import Compact from './toolbar/compact';
+
 import Save from './toolbar/save';
 
 import Edit from './toolbar/edit';
 
 import Voila from './toolbar/voila';
-import Compact from './toolbar/compact';
 
 /**
  * A `DocumentWidget` for Voila GridStack to host the toolbar and content area.

--- a/packages/jupyterlab-gridstack/src/editor/widget.ts
+++ b/packages/jupyterlab-gridstack/src/editor/widget.ts
@@ -13,6 +13,7 @@ import Save from './toolbar/save';
 import Edit from './toolbar/edit';
 
 import Voila from './toolbar/voila';
+import Compact from './toolbar/compact';
 
 /**
  * A `DocumentWidget` for Voila GridStack to host the toolbar and content area.
@@ -39,6 +40,7 @@ export class VoilaGridStackWidget extends DocumentWidget<
     // Adding the buttons to the widget toolbar
     this.toolbar.addItem('save', new Save(this.content));
     this.toolbar.addItem('edit', new Edit(this.content));
+    this.toolbar.addItem('compact', new Compact(this.content));
     this.toolbar.addItem('voila', new Voila(this.context.path));
   }
 }

--- a/packages/jupyterlab-gridstack/src/icons.ts
+++ b/packages/jupyterlab-gridstack/src/icons.ts
@@ -1,9 +1,15 @@
 import { LabIcon } from '@jupyterlab/ui-components';
 
 // icon svg import statements
-import pullRequest from '../style/icons/dashboard.svg';
+import compact from '../style/icons/compact.svg';
+import dashboard from '../style/icons/dashboard.svg';
+
+export const compactIcon = new LabIcon({
+  name: '@voila-dashboards/jupyterlab-gridstack:icon-compact',
+  svgstr: compact
+});
 
 export const dashboardIcon = new LabIcon({
   name: '@voila-dashboards/jupyterlab-gridstack:icon-dashboard',
-  svgstr: pullRequest
+  svgstr: dashboard
 });

--- a/packages/jupyterlab-gridstack/style/icons/compact.svg
+++ b/packages/jupyterlab-gridstack/style/icons/compact.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g class="jp-icon3" stroke="#616161" stroke-width="1">
+        <rect stroke-dasharray="2" width="22" height="22" x="1" y="1" />
+        <rect class="jp-icon3" fill="#616161" width="8" height="8" x="1" y="1" />
+        <path d="M 22 22 L 10 10" />
+        <path class="jp-icon3" fill="#616161" d="M 10 10 L 11 14 L 14 11 L 10 10" stroke-linecap="round"
+            stroke-linejoin="round" />
+    </g>
+</svg>

--- a/packages/jupyterlab-gridstack/style/index.css
+++ b/packages/jupyterlab-gridstack/style/index.css
@@ -3,8 +3,17 @@
 .grid-editor {
   width: 100%;
   height: 100%;
-  overflow: scroll;
+  overflow: auto;
   background-color: var(--jp-layout-color2);
+}
+
+.grid-editor .jp-grid-helper {
+  width: 100%;
+  margin-top: 10px;
+  text-align: center;
+  color: var(--jp-ui-font-color2);
+  position: absolute;
+  top: 0px;
 }
 
 .grid-stack {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,10 +1157,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupyter-widgets/base@^4.0.0-alpha.2", "@jupyter-widgets/base@^4.0.0-rc.0":
-  version "4.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyter-widgets/base/-/base-4.0.0-rc.0.tgz#84cc966ceb8c1241a72a7b0e37da92e04c0ce6e2"
-  integrity sha512-iqGFrHvPpMVNqyYx4X2F+1Fgu0fhsAp9kmB3yeD9V8HZRh1ksaQ7o9MZxCTOVXJClY59PJMOmiLefGHFhqDGKQ==
+"@jupyter-widgets/base@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyter-widgets/base/-/base-4.0.0.tgz#6935461a3bd78df5523022e1c3d370ae24c9a454"
+  integrity sha512-lBQgLYzq6C+XjfVJTidk+rckKo/+xlTgIm1XUtACA3BUz8bgi2du2zmbYkcrplJMwGub4QWP6GnKgM5ZZRhzYg==
   dependencies:
     "@jupyterlab/services" "^6.0.0"
     "@lumino/coreutils" "^1.2.0"
@@ -1173,12 +1173,12 @@
     jquery "^3.1.1"
     lodash "^4.17.4"
 
-"@jupyter-widgets/controls@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyter-widgets/controls/-/controls-3.0.0-rc.0.tgz#a08b5816ae79a3e7e1cd8e38b20da72bdcbcafe4"
-  integrity sha512-VA1JXpyW4kwnuZ0n5EMYlemY1QYC1fo9iuEeR4ctxB32PV7mrLjXNdNodeqQTGAa3BhtU42FY72MHKK+RQ+6bg==
+"@jupyter-widgets/controls@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyter-widgets/controls/-/controls-3.0.0.tgz#76e0c343627f0d300908e2dbdb524651f1be6315"
+  integrity sha512-VyoBxUp/8pf7IFlM4hriD/UvYpHzXFXrUAaT/NRAhMUFO4Ruh4ALcxeHdWFnqxMjiSyOnWdjzdIeQL0pYi83Gg==
   dependencies:
-    "@jupyter-widgets/base" "^4.0.0-rc.0"
+    "@jupyter-widgets/base" "^4.0.0"
     "@lumino/algorithm" "^1.1.0"
     "@lumino/domutils" "^1.1.0"
     "@lumino/messaging" "^1.2.1"
@@ -1189,14 +1189,14 @@
     jquery-ui "^1.12.1"
     underscore "^1.8.3"
 
-"@jupyter-widgets/jupyterlab-manager@^3.0.0-alpha.2":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyter-widgets/jupyterlab-manager/-/jupyterlab-manager-3.0.0-rc.0.tgz#582f0ca57c41dfaf4a48980dc716c4d665e50fb9"
-  integrity sha512-cih/sVN+CReoEvVGhw2njsdqEpWmlK8AbQizgtQKfw6u+i473awU0NsV4+2V22m2urFcCmyIXlqC5F6CaJOgcQ==
+"@jupyter-widgets/jupyterlab-manager@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyter-widgets/jupyterlab-manager/-/jupyterlab-manager-3.0.0.tgz#fa47d03e2e72399ce3af4b86cc29aba2166d5781"
+  integrity sha512-9diAvsHHiK/kY7bT8f2cNBkMN+6a3o18EDd9GBd7ER6zsOjZCBiASPl7ZfslWz7VNYLQdiRyxcKQSYU/tiXxdQ==
   dependencies:
-    "@jupyter-widgets/base" "^4.0.0-rc.0"
-    "@jupyter-widgets/controls" "^3.0.0-rc.0"
-    "@jupyter-widgets/output" "^4.0.0-rc.0"
+    "@jupyter-widgets/base" "^4.0.0"
+    "@jupyter-widgets/controls" "^3.0.0"
+    "@jupyter-widgets/output" "^4.0.0"
     "@jupyterlab/application" "^3.0.0"
     "@jupyterlab/docregistry" "^3.0.0"
     "@jupyterlab/logconsole" "^3.0.0"
@@ -1219,12 +1219,12 @@
     jquery "^3.1.1"
     semver "^6.1.1"
 
-"@jupyter-widgets/output@^4.0.0-rc.0":
-  version "4.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyter-widgets/output/-/output-4.0.0-rc.0.tgz#b4a5ce0b9e517e2344be1b6a42e2218d63d08340"
-  integrity sha512-UudG5eQ7Qper8MmjT4pDnYF9DN8LnKoicMO3BgzW/Fbxs63sGWAwCXvmh7pH5pCnDbswGVYfOQA3Xw9SakBIlw==
+"@jupyter-widgets/output@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyter-widgets/output/-/output-4.0.0.tgz#1dd759b1bfb699f707cc7fd0235a0e8d0c012c52"
+  integrity sha512-v9vyGhp6IFKKTSxlaa19Z9qo50ofGfvOwqlIyek6PzCAulE+8/UTGz4sw876Yts0cbCSQIwh1zF9HCQ8XfqH2A==
   dependencies:
-    "@jupyter-widgets/base" "^4.0.0-rc.0"
+    "@jupyter-widgets/base" "^4.0.0"
 
 "@jupyterlab/application@^3.0.0":
   version "3.0.0"
@@ -6036,10 +6036,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-gridstack@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-4.0.1.tgz#2a9dae7eab128421f747dd1a1d7e3a40766075db"
-  integrity sha512-wFRT5e9XtsN/vUdNN7j1y7Eu/kqwW5RWKdZGI7jJytyPXRGp3A45epGRrsXkZdEuRDKDFPxHG4FXB+i9+/tUjA==
+gridstack@^3.1.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-3.3.0.tgz#e324de1acbe59b812293117783c398ca83e2d1ca"
+  integrity sha512-xF8EF/CvUYRSaq0KRHA6ROHRuAxObqAVByBLyZfOPWOJBJTbg5GvPUj8HABEBYZWKxQeFkONcZwNflZLhHEi4g==
 
 growly@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6036,10 +6036,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-gridstack@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-3.1.3.tgz#982572b5d7b3608ab0463821a9798cab3766acaf"
-  integrity sha512-FNmuz5d1qRFXxK/tWj8PsAECyiFOX6Pnj4aaW+zd9BcTI9yY1hT7gq8y5CTBZ3vIy7VE+99jDwvb9WWchs0xlw==
+gridstack@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-4.0.1.tgz#2a9dae7eab128421f747dd1a1d7e3a40766075db"
+  integrity sha512-wFRT5e9XtsN/vUdNN7j1y7Eu/kqwW5RWKdZGI7jJytyPXRGp3A45epGRrsXkZdEuRDKDFPxHG4FXB+i9+/tUjA==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This PR fixes partly #87:
- When dropping a cell from a notebook, the widget size is set according to the cell size
- Add button to compact the grid on the top left corner
- Add helper text when there are no widgets in the editor
- Block dragging early - don't wait for the drop to tell the user a cell is not a valid source.

Failed to insert a virtual widget to help placing the cell when drag & dropping it from the notebook