### PR TITLE
Update cursor on grid widget toolbar

### DIFF
--- a/packages/jupyterlab-gridstack/style/index.css
+++ b/packages/jupyterlab-gridstack/style/index.css
@@ -32,6 +32,8 @@
   display: flex;
   justify-content: flex-end;
   background-color: var(--jp-layout-color2);
+  /* JupyterLab uses move cursor although `grab` would be more appropriate */
+  cursor: move;
 }
 
 .grid-item-widget {


### PR DESCRIPTION
Change cursor on grid widget toolbar to highlight it can be grabbed (actually use cursor _move_ to be coherent with JupyterLab)