### PR TITLE
Add revert button

### DIFF
--- a/packages/jupyterlab-gridstack/src/editor/panel.ts
+++ b/packages/jupyterlab-gridstack/src/editor/panel.ts
@@ -4,6 +4,8 @@ import {
   StaticNotebook
 } from '@jupyterlab/notebook';
 
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -122,6 +124,27 @@ export class VoilaGridStackPanel extends Panel {
    */
   info(): void {
     this._gridstackWidget?.infoEditor();
+  }
+
+  /**
+   * Reload the notebook from the disk
+   */
+  revert(): void {
+    if (this._context.model.dirty) {
+      showDialog({
+        title: 'Reload Notebook from Disk',
+        body: 'Are you sure you want to reload the Notebook from the disk?',
+        buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Reload' })]
+      }).then(result => {
+        if (result.button.accept && !this._context.isDisposed) {
+          this._context.revert();
+        }
+      });
+    } else {
+      if (!this._context.isDisposed) {
+        this._context.revert();
+      }
+    }
   }
 
   /**

--- a/packages/jupyterlab-gridstack/src/editor/panel.ts
+++ b/packages/jupyterlab-gridstack/src/editor/panel.ts
@@ -120,6 +120,13 @@ export class VoilaGridStackPanel extends Panel {
   }
 
   /**
+   * Compact the dashboard on the top left corner.
+   */
+  compact(): void {
+    this._gridstackWidget?.compact();
+  }
+
+  /**
    * Open a dialog to edit the gridstack metadata information.
    */
   info(): void {

--- a/packages/jupyterlab-gridstack/src/editor/toolbar/compact.tsx
+++ b/packages/jupyterlab-gridstack/src/editor/toolbar/compact.tsx
@@ -4,8 +4,6 @@ import * as React from 'react';
 
 import { compactIcon } from '../../icons';
 
-import { GridStackWidget } from '../gridstack/widget';
-
 import { VoilaGridStackPanel } from '../panel';
 
 /**
@@ -19,7 +17,7 @@ export default class Compact extends ReactWidget {
 
   render(): JSX.Element {
     const onClick = (): void => {
-      (this._panel?.widgets[0] as GridStackWidget)?.compact();
+      this._panel.compact();
     };
 
     return (

--- a/packages/jupyterlab-gridstack/src/editor/toolbar/revert.tsx
+++ b/packages/jupyterlab-gridstack/src/editor/toolbar/revert.tsx
@@ -1,0 +1,33 @@
+import { ReactWidget, ToolbarButtonComponent } from '@jupyterlab/apputils';
+
+import { undoIcon } from '@jupyterlab/ui-components';
+
+import * as React from 'react';
+
+import { VoilaGridStackPanel } from '../panel';
+
+/**
+ * A toolbar widget to reload the dashboard positions from disk.
+ */
+export default class Revert extends ReactWidget {
+  constructor(panel: VoilaGridStackPanel) {
+    super();
+    this._panel = panel;
+  }
+
+  render(): JSX.Element {
+    const onClick = (): void => {
+      this._panel.revert();
+    };
+
+    return (
+      <ToolbarButtonComponent
+        icon={undoIcon}
+        onClick={onClick}
+        tooltip={'Reload Notebook from Disk'}
+      />
+    );
+  }
+
+  private _panel: VoilaGridStackPanel;
+}

--- a/packages/jupyterlab-gridstack/src/editor/widget.ts
+++ b/packages/jupyterlab-gridstack/src/editor/widget.ts
@@ -14,6 +14,8 @@ import Save from './toolbar/save';
 
 import Edit from './toolbar/edit';
 
+import Revert from './toolbar/revert';
+
 import Voila from './toolbar/voila';
 
 /**
@@ -40,6 +42,7 @@ export class VoilaGridStackWidget extends DocumentWidget<
 
     // Adding the buttons to the widget toolbar
     this.toolbar.addItem('save', new Save(this.content));
+    this.toolbar.addItem('revert', new Revert(this.content));
     this.toolbar.addItem('edit', new Edit(this.content));
     this.toolbar.addItem('compact', new Compact(this.content));
     this.toolbar.addItem('voila', new Voila(this.context.path));


### PR DESCRIPTION
When playing around it could be nice to reload quickly the layout from disk instead of changing manually multiple widget.

> This also improve the API of the editor panel to be more consistent for the compact button.