### PR TITLE
Bump to gridstack 4.0.1 and drop jq

### DIFF
--- a/packages/jupyterlab-gridstack/package.json
+++ b/packages/jupyterlab-gridstack/package.json
@@ -55,7 +55,7 @@
     "@jupyterlab/ui-components": "^3.0.0",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/widgets": "^1.17.0",
-    "gridstack": "^3.1.3",
+    "gridstack": "^4.0.1",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -8,8 +8,6 @@ import { Message, MessageLoop } from '@lumino/messaging';
 
 import { GridStack, GridStackNode, GridItemHTMLElement } from 'gridstack';
 
-import 'gridstack/dist/gridstack.css';
-
 import 'gridstack/dist/h5/gridstack-dd-native';
 
 import { GridStackItem } from './item';

--- a/packages/jupyterlab-gridstack/style/index.css
+++ b/packages/jupyterlab-gridstack/style/index.css
@@ -1,3 +1,4 @@
+@import url('~gridstack/dist/gridstack.css');
 @import 'variables.css';
 
 .grid-editor {

--- a/share/jupyter/nbconvert/templates/gridstack/gridstack.js.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/gridstack.js.j2
@@ -1,15 +1,19 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
-
-<script src="https://cdn.jsdelivr.net/npm/gridstack@3.1.3/dist/gridstack-jq.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@4.0.1/dist/gridstack-h5.js"></script>
 <script type="text/javascript">
+    const debounce = (callback, wait) => {
+        let timeoutId = null;
+        return (...args) => {
+            window.clearTimeout(timeoutId);
+            timeoutId = window.setTimeout(() => {
+            callback.apply(null, args);
+            }, wait);
+        };
+    }
     // bqplot doesn't resize when resizing the tile, fix: fake a resize event
-    var resize_workaround = _.debounce(() => {
+    const resize_workaround = debounce(() => {
         window.dispatchEvent(new Event('resize'));
     }, 100)
-    $(function () {
+    window.onload = function () {
         GridStack.init({
             alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
             float: true,
@@ -43,7 +47,7 @@
         {% endif %}
 
         setCellNrs();
-    });
+    }
 </script>
 <script type="text/javascript">
   function updateConfig() {

--- a/share/jupyter/nbconvert/templates/gridstack/gridstack_base.html.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/gridstack_base.html.j2
@@ -1,7 +1,7 @@
 {%- extends 'lab/index.html.j2' -%}
 
 {% block html_head_css %}
-<link href="https://cdn.jsdelivr.net/npm/gridstack@3.1.3/dist/gridstack.min.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/npm/gridstack@4.0.1/dist/gridstack.min.css" rel="stylesheet" />
 {{ super() }}
 
 <style>

--- a/voila-gridstack/static/extension.js
+++ b/voila-gridstack/static/extension.js
@@ -15,7 +15,7 @@ define(['jquery',
        ],
        function($, Jupyter, gridstack, voila_gridstack) {
 
-    var GRIDSTACK_STYLES = 'https://cdn.jsdelivr.net/npm/gridstack@3.1.3/dist/gridstack.min.css';
+    var GRIDSTACK_STYLES = 'https://cdn.jsdelivr.net/npm/gridstack@4.0.1/dist/gridstack.min.css';
     var grid;
 
     function load_ipython_extension() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6036,10 +6036,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-gridstack@^3.1.3:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-3.3.0.tgz#e324de1acbe59b812293117783c398ca83e2d1ca"
-  integrity sha512-xF8EF/CvUYRSaq0KRHA6ROHRuAxObqAVByBLyZfOPWOJBJTbg5GvPUj8HABEBYZWKxQeFkONcZwNflZLhHEi4g==
+gridstack@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-4.0.1.tgz#2a9dae7eab128421f747dd1a1d7e3a40766075db"
+  integrity sha512-wFRT5e9XtsN/vUdNN7j1y7Eu/kqwW5RWKdZGI7jJytyPXRGp3A45epGRrsXkZdEuRDKDFPxHG4FXB+i9+/tUjA==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Bump gridstack to 4.0.1
Drop jq in template (use html5 implementation)
Drop lodash (use vanilla JS as only one function is used)
Import gridstack css logically in style for jupyterlab extension

Fixes #97 