### PR TITLE
Change launch button

### DIFF
--- a/packages/jupyterlab-gridstack/src/editor/components/notebookButtons.ts
+++ b/packages/jupyterlab-gridstack/src/editor/components/notebookButtons.ts
@@ -4,6 +4,8 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { NotebookPanel, INotebookModel } from '@jupyterlab/notebook';
 
+import { launcherIcon } from '@jupyterlab/ui-components';
+
 import { PageConfig } from '@jupyterlab/coreutils';
 
 import { CommandRegistry } from '@lumino/commands';
@@ -11,8 +13,6 @@ import { CommandRegistry } from '@lumino/commands';
 import { IDisposable } from '@lumino/disposable';
 
 import { dashboardIcon } from '../../icons';
-
-const VOILA_ICON_CLASS = 'jp-MaterialIcon jp-VoilaIcon';
 
 /**
  * A WidgetExtension for Notebook's toolbar to open a `VoilaGridstack` widget.
@@ -32,7 +32,7 @@ export class EditorButton
    */
   createNew(panel: NotebookPanel): IDisposable {
     const button = new ToolbarButton({
-      tooltip: 'Open with Voilà GridStack',
+      tooltip: 'Open with Voilà GridStack editor',
       icon: dashboardIcon,
       onClick: () => {
         this._commands.execute('docmanager:open', {
@@ -58,13 +58,12 @@ export class VoilaButton
    */
   createNew(panel: NotebookPanel): IDisposable {
     const button = new ToolbarButton({
-      className: 'voila',
-      tooltip: 'Open with Voilà in a New Browser Tab',
-      iconClass: VOILA_ICON_CLASS,
+      tooltip: 'Open with Voilà Gridstack in a New Browser Tab',
+      icon: launcherIcon,
       onClick: () => {
         const baseUrl = PageConfig.getBaseUrl();
         const win = window.open(
-          `${baseUrl}voila/render/${panel.context.path}`,
+          `${baseUrl}voila/render/${panel.context.path}?voila-template=gridstack`,
           '_blank'
         );
         win?.focus();

--- a/packages/jupyterlab-gridstack/src/editor/toolbar/voila.tsx
+++ b/packages/jupyterlab-gridstack/src/editor/toolbar/voila.tsx
@@ -1,5 +1,7 @@
 import { ReactWidget, ToolbarButtonComponent } from '@jupyterlab/apputils';
 
+import { launcherIcon } from '@jupyterlab/ui-components';
+
 import { PageConfig } from '@jupyterlab/coreutils';
 
 import * as React from 'react';
@@ -26,9 +28,9 @@ export default class Voila extends ReactWidget {
 
     return (
       <ToolbarButtonComponent
-        iconClass="jp-MaterialIcon jp-VoilaIcon"
+        icon={launcherIcon}
         onClick={onClick}
-        tooltip={'Open with Voilà in a New Browser Tab'}
+        tooltip={'Open with Voilà Gridstack in a New Browser Tab'}
       />
     );
   }


### PR DESCRIPTION
Solves #84 

Changed the icon and tooltip in the notebook toolbar and editor toolbar for consistency.
Now both open Voilà with the gridstack template.

I'm open to discussion about with icon to use.

![notebook-button](https://user-images.githubusercontent.com/26092748/112462392-4726c780-8d61-11eb-94ab-3c918711b230.png)

![editor-button](https://user-images.githubusercontent.com/26092748/112462399-4a21b800-8d61-11eb-8eb1-a05ad65e2e63.png)


