### PR TITLE
Style improvements

### DIFF
--- a/packages/jupyterlab-gridstack/style/index.css
+++ b/packages/jupyterlab-gridstack/style/index.css
@@ -63,6 +63,10 @@
   overflow: visible;
 }
 
+.grid-item-widget .jp-OutputArea-output {
+  overflow: visible;
+}
+
 .grid-item-widget .jupyter-widgets {
   overflow: visible;
 }

--- a/packages/jupyterlab-gridstack/style/index.css
+++ b/packages/jupyterlab-gridstack/style/index.css
@@ -33,21 +33,38 @@
   background-color: var(--jp-layout-color1);
 }
 
+.grid-stack .grid-stack-item .grid-stack-item-content {
+  padding: 4px;
+  overflow: auto;
+  border-radius: 5px;
+}
+
 .grid-item-toolbar {
   position: sticky;
   top: 0px;
+  left: 0px;
+  right: 0px;
   z-index: 1;
   height: fit-content;
-  margin: 2px;
+  margin-bottom: 4px;
   display: flex;
   justify-content: flex-end;
   background-color: var(--jp-layout-color2);
+  border-radius: 5px;
   /* JupyterLab uses move cursor although `grab` would be more appropriate */
   cursor: move;
 }
 
 .grid-item-widget {
-  margin: 2px;
+  margin-bottom: 4px;
+}
+
+.grid-item-widget .jp-OutputArea {
+  overflow: visible;
+}
+
+.grid-item-widget .jupyter-widgets {
+  overflow: visible;
 }
 
 .trash-can {


### PR DESCRIPTION
Small visible improvements and solves #113 
- Rounded borders for items.
- Keeps items' toolbar in the same position when scrolling.
- Move scrollbar to `gridstack-item`s 

Note: Couldn't improve the focus on the scrollbar. The vertical scrollbar it's almost impossible to click since gridstack handlers for resizing get the focus.

![image](https://user-images.githubusercontent.com/26092748/112488572-eeb1f300-8d7d-11eb-84b3-0689fc6fbb9d.png)
