### PR TITLE
Add tooltip when drag in is forbidden

### DIFF
--- a/packages/jupyterlab-gridstack/style/index.css
+++ b/packages/jupyterlab-gridstack/style/index.css
@@ -1,6 +1,13 @@
 @import url('~gridstack/dist/gridstack.css');
 @import 'variables.css';
 
+.grid-stack-error {
+  padding: 10px;
+  color: var(--jp-error-color0);
+  background-color: var(--jp-error-color3);
+  border: var(--jp-border-width) solid var(--jp-error-color2);
+}
+
 .grid-editor {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Fixes #108

This add an error message to the cell thumbnail.

I unfortunately was not able to find a way to remove the error message if the user get out of the GridStack editor - the drag element is capturing all events and if the drag even is accepted this leads to allowed drop.