### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches: '*'
 

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,10 +2,10 @@ name: Check Release
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
The default branch has been renamed to `main`.

This updates the few references to the new name.