### PR TITLE
Resize widgets when resizing cells or document

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -1,0 +1,15 @@
+name: Binder Badge
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/binder-link@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          url_path: lab/tree/examples


### PR DESCRIPTION
Resize widgets when resizing cells or document

This PR improves the UI/UX experience but has a downside in performance.

Every time the user resizes a cell, we propagate the resize event to the widget inside the cell. This rerenders the widget. Another possibility would be to propagate the event when the resize stops or debouce the propagation to not rerender the widget so many times.

Regarding the document, this PR listens for a resize event on the widget and, when the resize stops, propagates the event to every widget rendered in the layout.

Also added a new GitHub action to comment the binder link for each PR.

https://user-images.githubusercontent.com/26092748/146948913-d0e76771-37e0-4039-8596-9f900b08020f.mp4
