### PR TITLE
Update gridstack

### DIFF
--- a/packages/jupyterlab-gridstack/package.json
+++ b/packages/jupyterlab-gridstack/package.json
@@ -66,7 +66,7 @@
     "@lumino/messaging": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.19.0",
-    "gridstack": "^4.0.1",
+    "gridstack": "^4.4.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "yjs": "^13.5.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6973,10 +6973,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-gridstack@^4.0.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-4.3.1.tgz#dd9709fc5ba0a1e4ff64d8ed3319a95d88f2e21b"
-  integrity sha512-E4smuSe7ZZBrqPWm4THxDSYCQG4xcoQg8k0eeHjqkKiKuh3W4JFbyhA86DVarWruuZuUl2pwgO3oDhL6DFKFYw==
+gridstack@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-4.4.1.tgz#3b7b168aab575ccafc7be306bd67bff3d79d8bed"
+  integrity sha512-vOwo3X+tie0md/T8ODe+oyYrnOxw4+F9qLlhK9ZKToJ1hVGFvtLQ7a1mUkt42h1aJdF4G/nnEVkcdT46nSExeQ==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Updates to gridstack [v4.4.1](https://github.com/gridstack/gridstack.js/releases/tag/v4.4.1).