### PR TITLE
Automated Changelog Entry for 0.3.0b0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.0b0
+
+([Full Changelog](https://github.com/voila-dashboards/voila-gridstack/compare/v0.3.0a2...81c9d579ce17f32932b186e82298f8e81bc60a71))
+
+### Maintenance and upkeep improvements
+
+- Update release instructions [#161](https://github.com/voila-dashboards/voila-gridstack/pull/161) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila-gridstack/graphs/contributors?from=2022-01-02&to=2022-01-06&type=c))
+
+[@hbcarlos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila-gridstack+involves%3Ahbcarlos+updated%3A2022-01-02..2022-01-06&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.0a2
 
 ([Full Changelog](https://github.com/voila-dashboards/voila-gridstack/compare/v0.3.0a1...e1284e16aac0616dd44ce500f0969bcf7abb6c89))
@@ -19,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/voila-dashboards/voila-gridstack/graphs/contributors?from=2021-12-28&to=2022-01-02&type=c))
 
 [@hbcarlos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila-gridstack+involves%3Ahbcarlos+updated%3A2021-12-28..2022-01-02&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.0a1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.0b0 on main
```
Python version: 0.3.0b0
npm version: @voila-dashboards/voila-gridstack-root: 0.1.0
npm workspace versions:
@voila-dashboards/gridstack-editor: 0.3.0-beta.0
@voila-dashboards/jupyterlab-gridstack: 0.3.0-beta.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | voila-dashboards/voila-gridstack  |
| Branch  | main  |
| Version Spec | 0.3.0b0 |
| Since | v0.3.0a2 |