### PR TITLE
Automated Changelog Entry for 0.3.0b1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.0b1
+
+([Full Changelog](https://github.com/voila-dashboards/voila-gridstack/compare/v0.3.0b0...42d8934c074fccd5d65ac25a35bbba2dc815d186))
+
+### Maintenance and upkeep improvements
+
+- Update gridstack v5 [#164](https://github.com/voila-dashboards/voila-gridstack/pull/164) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila-gridstack/graphs/contributors?from=2022-01-06&to=2022-01-12&type=c))
+
+[@hbcarlos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila-gridstack+involves%3Ahbcarlos+updated%3A2022-01-06..2022-01-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.0b0
 
 ([Full Changelog](https://github.com/voila-dashboards/voila-gridstack/compare/v0.3.0a2...81c9d579ce17f32932b186e82298f8e81bc60a71))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/voila-dashboards/voila-gridstack/graphs/contributors?from=2022-01-02&to=2022-01-06&type=c))
 
 [@hbcarlos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila-gridstack+involves%3Ahbcarlos+updated%3A2022-01-02..2022-01-06&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.0a2
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.0b1 on main
```
Python version: 0.3.0b1
npm version: @voila-dashboards/voila-gridstack-root: 0.1.0
npm workspace versions:
@voila-dashboards/gridstack-editor: 0.3.0-beta.1
@voila-dashboards/jupyterlab-gridstack: 0.3.0-beta.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | voila-dashboards/voila-gridstack  |
| Branch  | main  |
| Version Spec | 0.3.0b1 |
| Since | v0.3.0b0 |