### PR TITLE
Updates to gridstack v6.0.1

### DIFF
--- a/packages/jupyterlab-gridstack/package.json
+++ b/packages/jupyterlab-gridstack/package.json
@@ -66,7 +66,7 @@
     "@lumino/messaging": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.19.0",
-    "gridstack": "^5.0.0",
+    "gridstack": "^6.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "yjs": "^13.5.6"

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/layout.ts
@@ -8,8 +8,6 @@ import { Message, MessageLoop } from '@lumino/messaging';
 
 import { GridStack, GridStackNode, GridItemHTMLElement } from 'gridstack';
 
-import 'gridstack/dist/h5/gridstack-dd-native';
-
 import { GridStackItemWidget } from '../item';
 
 import { DashboardView, DashboardCellView } from '../format';

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
 [options.extras_require]
 test =
     ipykernel
+    nbconvert==6.5.0
     pytest
     pytest-tornasync
     lxml

--- a/share/jupyter/nbconvert/templates/gridstack/gridstack.js.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/gridstack.js.j2
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/gridstack@5/dist/gridstack-h5.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@6.0.1/dist/gridstack-all.js"></script>
 <script type="text/javascript">
     const debounce = (callback, wait) => {
         let timeoutId = null;

--- a/share/jupyter/nbconvert/templates/gridstack/gridstack_base.html.j2
+++ b/share/jupyter/nbconvert/templates/gridstack/gridstack_base.html.j2
@@ -1,7 +1,7 @@
 {%- extends 'lab/index.html.j2' -%}
 
 {% block html_head_css %}
-<link href="https://cdn.jsdelivr.net/npm/gridstack@5/dist/gridstack.min.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/npm/gridstack@6.0.1/dist/gridstack.min.css" rel="stylesheet" />
 {{ super() }}
 
 <style>
@@ -39,6 +39,18 @@
     background: var(--jp-layout-color0);
 {% endif %}
     color: var(--jp-ui-font-color0);
+}
+
+.jp-OutputArea {
+    overflow-y: unset !important;
+}
+
+.jp-OutputArea-output {
+    overflow: unset !important;
+}
+
+.jp-OutputArea pre {
+    overflow: unset !important;
 }
 
 .ui-resizable-se {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7022,10 +7022,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-gridstack@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-5.0.0.tgz#b3b3f54f0bfda505d1e67c033d079b74622e00e3"
-  integrity sha512-FpXQ2gWUCcBW7QON7GEqP7NZFWZPpuGfze4dzRMQ1ikaRZ7Y2qfc9Gbc04Qukjst2AuPQcuW/mEJkh+2XnnCsA==
+gridstack@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-6.0.1.tgz#05b1ae49913fe9a6b36f4fe4219340457299dbc0"
+  integrity sha512-j7FbRbkYjMr/pKPHRkAx9j9N4q+3+v6UfPnIf0zM3CJtA1HOFxpTLHjnKtqvCGm0hdH0jSPuC9NmxlA4x/oXKg==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Updates to [gridstack v6.0.1](https://github.com/gridstack/gridstack.js/releases/tag/v6.0.1)

It also fixes a small bug in the template where the cell shows the scroll bar when the output has only one line.