### PR TITLE
[doc] fix binder paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ A gridstack-based template for [![voila-gridstack](assets/voila.png)](https://gi
       </a>
     </td>
     <td align="center">
-      <a href="https://mybinder.org/v2/gh/voila-dashboards/voila-gridstack/stable?urlpath=voila/tree/examples/scotch_dashboard.ipynb">
+      <a href="https://mybinder.org/v2/gh/voila-dashboards/voila-gridstack/main?urlpath=voila/tree/examples/scotch_dashboard.ipynb">
         <img src="https://mybinder.org/badge_logo.svg" alt="Voila GridStack on Binder"/>
       </a>
     </td>
     <td align="center">
-      <a href="https://mybinder.org/v2/gh/voila-dashboards/voila-gridstack/stable?urlpath=lab/tree/examples">
+      <a href="https://mybinder.org/v2/gh/voila-dashboards/voila-gridstack/main?urlpath=lab/tree/examples">
         <img src="https://mybinder.org/badge_logo.svg" alt="JupyterLab on Binder"/>
       </a>
     </td>


### PR DESCRIPTION
There is no `stable` branch. This replaces it with `main`.