### PR TITLE
Add Labextension directory to wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ artifacts = [
 ]
 exclude = ["/.github", "/binder", "node_modules", "assets", "docs", "examples"]
 
+[tool.hatch.build.targets.wheel]
+packages = ["voila_gridstack"]
+
 [tool.hatch.build.targets.wheel.shared-data]
 "voila_gridstack/config/jpserver-voila-gridstack.json" = "etc/jupyter/jupyter_server_config.d/jpserver-voila-gridstack.json"
 "voila_gridstack/config/nbserver-voila-gridstack.json" = "etc/jupyter/jupyter_notebook_config.d/nbserver-voila-gridstack.json"
@@ -72,6 +75,9 @@ exclude = ["/.github", "/binder", "node_modules", "assets", "docs", "examples"]
 "voila_gridstack/labextension" = "share/jupyter/labextensions/@voila-dashboards/jupyterlab-gridstack"
 "voila_gridstack/nbextension" = "share/jupyter/nbextensions/voila-gridstack"
 "voila_gridstack/template" = "share/jupyter/nbconvert/templates/gridstack"
+
+[tool.hatch.build.targets.wheel.force-include]
+"voila_gridstack/labextension" = "voila_gridstack/labextension"
 
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = ["hatch-jupyter-builder>=0.6.2"]


### PR DESCRIPTION
Resolves this error message when installing the package via pip when building a docker image of Jupyterlab:

```
File "/opt/conda/lib/python3.11/site-packages/voila_gridstack/__init__.py", line 18, in <module>
 with open(osp.join(HERE, 'labextension', 'package.json')) as fid:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/opt/conda/lib/python3.11/site-packages/voila_gridstack/labextension/package.json'
```